### PR TITLE
Fix and update Boost URL to latest v1.77.0 release

### DIFF
--- a/org.cloudcompare.CloudCompare.yaml
+++ b/org.cloudcompare.CloudCompare.yaml
@@ -69,8 +69,8 @@ modules:
   - name: boost
     sources:
       - type: archive
-        url: https://dl.bintray.com/boostorg/release/1.73.0/source/boost_1_73_0.tar.gz
-        sha256: 9995e192e68528793755692917f9eb6422f3052a53c5e13ba278a228af6c7acf
+        url: https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/boost_1_77_0.tar.gz
+        sha256: 5347464af5b14ac54bb945dc68f1dd7c56f0dad7262816b956138fc53bcc0131
     buildsystem: simple
     build-commands:
     - ./bootstrap.sh --prefix=/app --with-libraries=thread,system,date_time,filesystem,iostreams,atomic,chrono


### PR DESCRIPTION
The old URL for v1.73.0 returned just 403 Forbidden. Already touching
the version, so update to latest release.

Found here: https://github.com/flathub/org.cloudcompare.CloudCompare/pull/10#issuecomment-981752552