### PR TITLE
Update rdblib dependency to v2.3.8

### DIFF
--- a/org.cloudcompare.CloudCompare.yaml
+++ b/org.cloudcompare.CloudCompare.yaml
@@ -77,12 +77,12 @@ modules:
     sources:
       - type: archive
         only-arches: ["x86_64"]
-        url: https://repository.riegl.com/software/libraries/rdblib/archive/2.3.7/linux/rdblib-2.3.7-x86_64-linux.tar.gz
-        sha256: 181ff40b6145c9af8ff0d38cfa2f89480bf57c308e63a810e0760a791cf5d75c
+        url: https://repository.riegl.com/software/libraries/rdblib/archive/2.3.8/linux/rdblib-2.3.8-x86_64-linux.tar.gz
+        sha256: ef55342701a9953b5587e8d20fb7fff1a26dd9a9895a514cdc6a2e47980cf260
       - type: archive
         only-arches: ["aarch64"]
-        url: https://repository.riegl.com/software/libraries/rdblib/archive/2.3.7/linux/rdblib-2.3.7-arm64-linux.tar.gz
-        sha256: a3867888595fb4794c9643de3685afdc9b2f6ba196f552b6ce18ec11b16dbc20
+        url: https://repository.riegl.com/software/libraries/rdblib/archive/2.3.8/linux/rdblib-2.3.8-arm64-linux.tar.gz
+        sha256: dd08f5067e10f8b314f91b8786e8b6cc0d83c8be8447ffee74b4ab70f0751e1b
     buildsystem: simple
     build-commands:
     - mkdir -p /app/rdblib


### PR DESCRIPTION
A new version of rdblib has been released. Update this dependency to the latest release to support reading files created with rdblib 2.3.8. As a note: RDB files created with older versions of rdblib are readable by newer version of rdblib (backwards compatiblity)