### PR TITLE
CloudCompare 2.12 release

### DIFF
--- a/org.cloudcompare.CloudCompare.appdata.xml
+++ b/org.cloudcompare.CloudCompare.appdata.xml
@@ -3,7 +3,7 @@
   <id>org.cloudcompare.CloudCompare</id>
   <name>CloudCompare</name>
   <releases>
-    <release date="2021-11-23" version="2.12-beta"/>
+    <release date="2022-03-31" version="2.12"/>
   </releases>
   <project_license>GPL-2.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>

--- a/org.cloudcompare.CloudCompare.yaml
+++ b/org.cloudcompare.CloudCompare.yaml
@@ -332,7 +332,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/CloudCompare/CloudCompare.git
-        commit: 5523e9d1e8920127d043527cfb4ca4fe48147611
+        tag: v2.12.0
       # fix libE57Format compilation with clang
       # https://github.com/asmaloney/libE57Format/issues/93
       - type: patch


### PR DESCRIPTION
Switch from 2.12 beta to the final release.