### PR TITLE
Remove redundant access to home directory, already have host access

### DIFF
--- a/org.cloudcompare.CloudCompare.yaml
+++ b/org.cloudcompare.CloudCompare.yaml
@@ -11,7 +11,6 @@ finish-args:
   - --share=ipc
   - --device=dri
   - --share=network
-  - --filesystem=home
   - --filesystem=host
 
 cleanup:


### PR DESCRIPTION
From the documentation on the sandbox permissions: https://docs.flatpak.org/en/latest/sandbox-permissions-reference.html

- `host`: Access all files (Except for the blacklisted paths mentioned in Sandbox Permissions.)
- `home`: Access the home directory

This fixes the error: `finish-args-redundant-home-and-host`

Fixes: https://github.com/flathub/org.cloudcompare.CloudCompare/issues/23