### PR TITLE
2.13 final

### DIFF
--- a/3DFin.yaml
+++ b/3DFin.yaml
@@ -38,5 +38,5 @@ sources:
   url: https://files.pythonhosted.org/packages/a3/fb/52b62131e21b24ee297e4e95ed41eba29647dad0e0051a92bb66b43c70ff/tzdata-2023.4-py2.py3-none-any.whl
   sha256: aa3ace4329eeacda5b7beb7ea08ece826c28d761cda36e747cfbf97996d39bf3
 - type: file
-  url: https://files.pythonhosted.org/packages/5c/f9/a5bfac21ae2454f04bca9eafe65b96b576fd8ee2d8a025852d37ab493672/3dfin-0.3.0-py3-none-any.whl
-  sha256: 90a5aef5761fcc85b090dc620f816436f6efe8f5e552377c7b08b0710d69fe95
+  url: https://files.pythonhosted.org/packages/50/22/83d10cf6ef04c18a3e28cbf6631bc875d9ced5172323ece97d1dc1491405/3dfin-0.3.1-py3-none-any.whl
+  sha256: 3fd5fc3d051a9748de458a4ec751fc841dd5849cf2f1bd5c3a3477471ac20d44

--- a/org.cloudcompare.CloudCompare.appdata.xml
+++ b/org.cloudcompare.CloudCompare.appdata.xml
@@ -3,7 +3,7 @@
   <id>org.cloudcompare.CloudCompare</id>
   <name>CloudCompare</name>
   <releases>
-    <release date="2023-01-19" version="2.13.rc3"/>
+    <release date="2023-02-2" version="2.13"/>
   </releases>
   <project_license>GPL-3.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>

--- a/org.cloudcompare.CloudCompare.yaml
+++ b/org.cloudcompare.CloudCompare.yaml
@@ -379,7 +379,7 @@ modules:
         path: patches/q3DMASC.patch # Should be fixed upstream
       - type: git
         url: https://github.com/tmontaigu/CloudCompare-PythonRuntime.git
-        commit: 5dfdb6effc657531e002363217b05de8c20bda76 
+        commit: b1896c0ef69b536bc6c19a3bd1df5e9a1e1d8162 
         dest: plugins/private/CloudCompare-PythonRuntime
       - type: patch
         path: patches/CloudCompare-PythonRuntime.patch

--- a/org.cloudcompare.CloudCompare.yaml
+++ b/org.cloudcompare.CloudCompare.yaml
@@ -388,6 +388,9 @@ modules:
       cxxflags: -I/usr/include/python3.11 -Wno-deprecated-declarations # reduce QT deprecations noise, should be fixed upstream
     buildsystem: cmake-ninja
     config-opts:
+      - -DCMAKE_BUILD_TYPE=Release # implicit use for CGAL warning
+      - -DCCCORELIB_USE_CGAL=ON
+      - -DCCCORELIB_USE_TBB=ON
       - -DOPTION_USE_GDAL=ON
       - -DOPTION_USE_DXF_LIB=ON
       - -DOPTION_USE_SHAPE_LIB=ON

--- a/org.cloudcompare.CloudCompare.yaml
+++ b/org.cloudcompare.CloudCompare.yaml
@@ -374,7 +374,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/CloudCompare/CloudCompare.git
-        commit: adb5cbda26457170bb352747aa738178902d41d1
+        commit: 2fee143b06110ca21cce1af23bf796176ee2033f
       - type: patch
         path: patches/q3DMASC.patch # Should be fixed upstream
       - type: git


### PR DESCRIPTION
It should be (hopefully) the last PR of the 2.13 cycle.
This PR update few dependencies.
CCCoreLib was previously build without TBB nor CGAL support enabled, even if the libs where declared and build into the process.