### PR TITLE
Release 2.13.1

### DIFF
--- a/3DFin.yaml
+++ b/3DFin.yaml
@@ -8,8 +8,8 @@ build-commands:
   --prefix=${FLATPAK_DEST} --no-build-isolation python_dateutil pytz tzdata dendromatics lazrs pandas pydantic XlsxWriter 3DFin
 sources:
 - type: file
-  url: https://files.pythonhosted.org/packages/70/57/7f7f764aaef1f687f892a9a75034201e8c62d617bb33da40a9b004b1216d/dendromatics-0.4.1-py3-none-any.whl
-  sha256: acaf4975002c3e62121ec60b7370685fdd76bf67a3a1182d375229f213126f35
+  url: https://files.pythonhosted.org/packages/db/ce/9f457ee76dc95c7bc0b8101a75621e509c37e325e850cdc2f2d58f21502e/dendromatics-0.4.2-py3-none-any.whl
+  sha256: b54ddca9e3a074a54c772090e1be6119b6a47883377cf531cf21a507c04f6dfd
 - type: file
   url: https://files.pythonhosted.org/packages/d1/7f/0eac494e5b87d313a19e19bd8a0c9d012b60c7e042acd8a9b55af251d32f/lazrs-0.5.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: 85899e3c6c7af5989d8bfe1446515e8290794b423a0dd3f237dc5d0b3038300a
@@ -38,5 +38,5 @@ sources:
   url: https://files.pythonhosted.org/packages/a3/fb/52b62131e21b24ee297e4e95ed41eba29647dad0e0051a92bb66b43c70ff/tzdata-2023.4-py2.py3-none-any.whl
   sha256: aa3ace4329eeacda5b7beb7ea08ece826c28d761cda36e747cfbf97996d39bf3
 - type: file
-  url: https://files.pythonhosted.org/packages/33/9a/aba5dc915029c45d68d32a430ac7df63267dafd6e39119aaa5e7d9842803/3dfin-0.3.2-py3-none-any.whl
-  sha256: c823e4ebfa279a4fceb26fa780d1ab13c12531591c284f3a186f2573f9c92e31
+  url: https://files.pythonhosted.org/packages/d5/6e/1f2a8a7e48f156851d8f94a0ef5969c28b55574c9637a8ae194feb4c40c7/3dfin-0.3.3-py3-none-any.whl
+  sha256: 79fb3b934722260fdc3d48ac2349742637fa90042ed555c1469552043e128442

--- a/dendromatics.yaml
+++ b/dendromatics.yaml
@@ -8,8 +8,8 @@ build-commands:
   laspy numpy joblib threadpoolctl click scikit-learn scipy typer jakteristics pip
 sources:
 - type: file
-  url: https://files.pythonhosted.org/packages/15/cc/c5cea380edaba84969184e19d7ba8e3573cc07c9155361c96e09453b61c3/CSF_3DFin-1.1.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  sha256: dea604a7593ae092f34120672afaf77d744d73be5beb10fbc038659eba5eca89
+  url: https://files.pythonhosted.org/packages/29/7d/4234d5123f0e12e209b505e72396334362a469737ec97e4a39e49fcecd1b/CSF_3DFin-1.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: a24d9da81fef6cc5940483754bde96de75fe678b0568df27a432bd689acb6781
   only-arches:
   - x86_64
 - type: file

--- a/org.cloudcompare.CloudCompare.appdata.xml
+++ b/org.cloudcompare.CloudCompare.appdata.xml
@@ -3,7 +3,7 @@
   <id>org.cloudcompare.CloudCompare</id>
   <name>CloudCompare</name>
   <releases>
-    <release date="2024-03-20" version="2.13.1.rc2"/>
+    <release date="2024-03-20" version="2.13.1"/>
   </releases>
   <project_license>GPL-3.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>

--- a/org.cloudcompare.CloudCompare.appdata.xml
+++ b/org.cloudcompare.CloudCompare.appdata.xml
@@ -3,7 +3,7 @@
   <id>org.cloudcompare.CloudCompare</id>
   <name>CloudCompare</name>
   <releases>
-    <release date="2024-03-14" version="2.13.1.rc1"/>
+    <release date="2024-03-20" version="2.13.1.rc2"/>
   </releases>
   <project_license>GPL-3.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>

--- a/org.cloudcompare.CloudCompare.yaml
+++ b/org.cloudcompare.CloudCompare.yaml
@@ -372,8 +372,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/CloudCompare/CloudCompare.git
-        branch: various_improvements
-        commit: 7bd508a70a317f2f5608dba3c0a74f89189d6d7d
+        tag: v2.13.1
       - type: git
         url: https://github.com/tmontaigu/CloudCompare-PythonRuntime.git
         commit: f3ce345971a63fa50ebdb08d8db532e050fbea3a

--- a/org.cloudcompare.CloudCompare.yaml
+++ b/org.cloudcompare.CloudCompare.yaml
@@ -373,7 +373,7 @@ modules:
       - type: git
         url: https://github.com/CloudCompare/CloudCompare.git
         branch: various_improvements
-        commit: 9c7e29a71169b7941fbfa60f5fab41ca2a496457
+        commit: 7bd508a70a317f2f5608dba3c0a74f89189d6d7d
       - type: git
         url: https://github.com/tmontaigu/CloudCompare-PythonRuntime.git
         commit: f3ce345971a63fa50ebdb08d8db532e050fbea3a


### PR DESCRIPTION
- Update 3DFin
- Update CC to current v2.13.1 tag
(this is to be merged into `master` branch after `beta`)