### PR TITLE
Update org.cloudcompare.CloudCompare.appdata.xml

### DIFF
--- a/org.cloudcompare.CloudCompare.appdata.xml
+++ b/org.cloudcompare.CloudCompare.appdata.xml
@@ -3,7 +3,7 @@
   <id>org.cloudcompare.CloudCompare</id>
   <name>CloudCompare</name>
   <releases>
-    <release date="2024-08-04" version="2.13.2"/>
+    <release date="2024-07-11" version="2.13.2"/>
   </releases>
   <project_license>GPL-3.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>


### PR DESCRIPTION
Update Release date in appdata
- The date was wrong 
- We want to trigger another build with the v2.13.2 tag pointing (at last) on the good commit.