### PR TITLE
Enhancement for flatpak-builder v1.4.4

### DIFF
--- a/org.cloudcompare.CloudCompare.yaml
+++ b/org.cloudcompare.CloudCompare.yaml
@@ -380,7 +380,7 @@ modules:
         path: patches/CloudCompare-PythonRuntime.patch
     builddir: true
     build-options:
-      cxxflags: -I/usr/include/python3.11 -I/app/include/opencv4 -Wno-deprecated-declarations # reduce QT deprecations noise, should be fixed upstream
+      cxxflags: -I/usr/include/python3.11 -Wno-deprecated-declarations # reduce QT deprecations noise, should be fixed upstream
     buildsystem: cmake-ninja
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release # implicit use for CGAL warning


### PR DESCRIPTION
due to a bug/change in flatpak-builder v1.4.3 we were force to hardcode some include path (openCV in our case) it seems to be fixed by 1.4.4.

(note this build can fail online if flathub server are still running 1.4.3)